### PR TITLE
Adds a CLI for rendering and validating Roadlines; fixes bugs in representation and rednering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5296,6 +5296,9 @@ dependencies = [
  "anyhow",
  "clap",
  "clap-markdown-ext",
+ "roadline-bevy-renderer",
+ "roadline-parser-markdown",
+ "roadline-representation-core",
  "thiserror 1.0.69",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,6 +1625,32 @@ name = "camino"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1de8bc0aa9e9385ceb3bf0c152e3a9b9544f6c4a912c8ae504e80c1f0368603"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.16",
+]
 
 [[package]]
 name = "caseless"
@@ -1707,6 +1733,25 @@ checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-markdown"
+version = "0.1.4"
+source = "git+https://github.com/ConnorGray/clap-markdown.git?rev=1e1ae469444604d5b9ee650232abc2d3a0fa723b#1e1ae469444604d5b9ee650232abc2d3a0fa723b"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap-markdown-ext"
+version = "0.0.1"
+source = "git+https://github.com/movementlabsxyz/clap-markdown-ext.git?rev=8f54fe424504bf37fb01dc69aaed8166e429fe6a#8f54fe424504bf37fb01dc69aaed8166e429fe6a"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "clap",
+ "clap-markdown",
 ]
 
 [[package]]
@@ -5245,6 +5290,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "roadline"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "clap-markdown-ext",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "roadline-bevy-renderer"
 version = "0.0.1"
 dependencies = [
@@ -5567,6 +5623,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "send_wrapper"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,10 @@ members = [
   "core/source/*",
 
   # site
-  "site/leptos-bevy"
+  "site/leptos-bevy",
+
+  # cli
+  "cli/roadline"
   
 ]
 

--- a/cli/roadline/Cargo.toml
+++ b/cli/roadline/Cargo.toml
@@ -15,6 +15,9 @@ thiserror = { workspace = true }
 clap = { workspace = true }
 clap-markdown-ext = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+roadline-parser-markdown = { workspace = true }
+roadline-representation-core = { workspace = true }
+roadline-bevy-renderer = { workspace = true }
 
 [lints]
 workspace = true

--- a/cli/roadline/Cargo.toml
+++ b/cli/roadline/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "roadline"
+version = { workspace = true }
+edition = "2021"
+license = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+publish = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+clap = { workspace = true }
+clap-markdown-ext = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+
+[lints]
+workspace = true

--- a/cli/roadline/src/lib.rs
+++ b/cli/roadline/src/lib.rs
@@ -1,0 +1,38 @@
+pub mod render;
+
+use clap::Parser;
+use clap_markdown_ext::Markdown;
+
+#[derive(Debug, thiserror::Error)]
+pub enum RoadlineError {
+	#[error("Encountered an error while generating documentation: {0}")]
+	MarkdownError(#[from] anyhow::Error),
+	#[error("Encountered an error while running the program: {0}")]
+	RenderError(#[from] render::RenderError),
+}
+
+#[derive(Parser)]
+#[clap(rename_all = "kebab-case")]
+pub enum Roadline {
+	/// Generate CLI documentation
+	#[clap(subcommand)]
+	Markdown(Markdown),
+	/// Run a RISC-V program in the box
+	#[clap(subcommand)]
+	Render(render::Render),
+}
+
+impl Roadline {
+	pub async fn execute(&self) -> Result<(), RoadlineError> {
+		match self {
+			Roadline::Markdown(markdown) => {
+				markdown.execute::<Self>().await?;
+			}
+			Roadline::Render(render) => {
+				render.execute().await?;
+			}
+		}
+
+		Ok(())
+	}
+}

--- a/cli/roadline/src/lib.rs
+++ b/cli/roadline/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod render;
+pub mod validate;
 
 use clap::Parser;
 use clap_markdown_ext::Markdown;
@@ -9,6 +10,8 @@ pub enum RoadlineError {
 	MarkdownError(#[from] anyhow::Error),
 	#[error("Encountered an error while running the program: {0}")]
 	RenderError(#[from] render::RenderError),
+	#[error("Encountered an error while validating the roadline: {0}")]
+	ValidationError(#[from] validate::ValidationError),
 }
 
 #[derive(Parser)]
@@ -17,9 +20,11 @@ pub enum Roadline {
 	/// Generate CLI documentation
 	#[clap(subcommand)]
 	Markdown(Markdown),
-	/// Run a RISC-V program in the box
+	/// Render the roadline
 	#[clap(subcommand)]
 	Render(render::Render),
+	/// Validate the roadline
+	Validate(validate::Validate),
 }
 
 impl Roadline {
@@ -30,6 +35,9 @@ impl Roadline {
 			}
 			Roadline::Render(render) => {
 				render.execute().await?;
+			}
+			Roadline::Validate(validate) => {
+				validate.execute().await?;
 			}
 		}
 

--- a/cli/roadline/src/main.rs
+++ b/cli/roadline/src/main.rs
@@ -1,0 +1,14 @@
+use clap::Parser;
+use roadline::{Roadline, RoadlineError};
+
+#[tokio::main]
+async fn main() -> Result<(), RoadlineError> {
+	let roadline = Roadline::parse();
+	match roadline.execute().await {
+		Ok(()) => Ok(()),
+		Err(e) => {
+			eprintln!("Error: {}", e);
+			Ok(())
+		}
+	}
+}

--- a/cli/roadline/src/render.rs
+++ b/cli/roadline/src/render.rs
@@ -1,0 +1,23 @@
+pub mod bevy;
+
+use clap::Subcommand;
+
+#[derive(Debug, thiserror::Error)]
+pub enum RenderError {
+	#[error("Encountered an error while rendering with Bevy: {0}")]
+	BevyError(#[from] bevy::BevyError),
+}
+
+#[derive(Subcommand)]
+pub enum Render {
+	/// Load and run a RISC-V ELF file
+	Bevy(bevy::Bevy),
+}
+
+impl Render {
+	pub async fn execute(&self) -> Result<(), RenderError> {
+		match self {
+			Render::Bevy(bevy) => bevy.execute().await.map_err(RenderError::BevyError),
+		}
+	}
+}

--- a/cli/roadline/src/render/bevy.rs
+++ b/cli/roadline/src/render/bevy.rs
@@ -1,0 +1,17 @@
+use clap::Parser;
+
+#[derive(Debug, thiserror::Error)]
+pub enum BevyError {
+	#[error("Encountered an internal error: {0}")]
+	Internal(#[from] anyhow::Error),
+}
+
+#[derive(Parser)]
+#[clap(rename_all = "kebab-case")]
+pub struct Bevy {}
+
+impl Bevy {
+	pub async fn execute(&self) -> Result<(), BevyError> {
+		unimplemented!()
+	}
+}

--- a/cli/roadline/src/render/bevy.rs
+++ b/cli/roadline/src/render/bevy.rs
@@ -1,17 +1,38 @@
 use clap::Parser;
+use roadline_bevy_renderer::RoadlineRenderer;
+use roadline_parser_markdown::RoadlineParser;
+use std::path::PathBuf;
 
 #[derive(Debug, thiserror::Error)]
 pub enum BevyError {
 	#[error("Encountered an internal error: {0}")]
-	Internal(#[from] anyhow::Error),
+	Internal(#[from] Box<dyn std::error::Error>),
 }
 
 #[derive(Parser)]
 #[clap(rename_all = "kebab-case")]
-pub struct Bevy {}
+pub struct Bevy {
+	/// The path to the markdown file to render
+	#[clap(long)]
+	pub path: PathBuf,
+}
 
 impl Bevy {
 	pub async fn execute(&self) -> Result<(), BevyError> {
-		unimplemented!()
+		let parser = RoadlineParser::new();
+		let content =
+			std::fs::read_to_string(&self.path).map_err(|e| BevyError::Internal(Box::new(e)))?;
+		let roadline =
+			parser.parse_and_build(&content).map_err(|e| BevyError::Internal(Box::new(e)))?;
+
+		let renderer = RoadlineRenderer::new();
+
+		let mut app = renderer
+			.create_app_with_roadline(roadline)
+			.map_err(|e| BevyError::Internal(Box::new(e)))?;
+
+		app.run();
+
+		Ok(())
 	}
 }

--- a/cli/roadline/src/validate.rs
+++ b/cli/roadline/src/validate.rs
@@ -1,0 +1,17 @@
+use clap::Parser;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ValidationError {
+	#[error("Encountered an internal error: {0}")]
+	Internal(#[from] anyhow::Error),
+}
+
+#[derive(Parser)]
+#[clap(rename_all = "kebab-case")]
+pub struct Validate {}
+
+impl Validate {
+	pub async fn execute(&self) -> Result<(), ValidationError> {
+		unimplemented!()
+	}
+}

--- a/core/parser/markdown/src/dependency.rs
+++ b/core/parser/markdown/src/dependency.rs
@@ -78,6 +78,8 @@ impl DependencyParser {
 	) -> Result<Option<Vec<TaskId>>, MarkdownParseError> {
 		let value = value.trim();
 
+		println!("dependency parser value: {}", value);
+
 		// Handle empty set
 		if value == "$\\emptyset$" || value.is_empty() {
 			return Ok(Some(Vec::new()));

--- a/core/parser/markdown/src/dependency.rs
+++ b/core/parser/markdown/src/dependency.rs
@@ -78,8 +78,6 @@ impl DependencyParser {
 	) -> Result<Option<Vec<TaskId>>, MarkdownParseError> {
 		let value = value.trim();
 
-		println!("dependency parser value: {}", value);
-
 		// Handle empty set
 		if value == "$\\emptyset$" || value.is_empty() {
 			return Ok(Some(Vec::new()));

--- a/core/parser/markdown/src/error.rs
+++ b/core/parser/markdown/src/error.rs
@@ -1,98 +1,94 @@
 //! Error types for markdown parsing.
 
-use thiserror::Error;
 use roadline_representation_core::roadline::RoadlineBuilderError;
+use thiserror::Error;
 
 /// Comprehensive error type for markdown parsing operations.
 #[derive(Debug, Error)]
 pub enum MarkdownParseError {
-    /// No tasks were found in the markdown content.
-    #[error("No tasks found in markdown content")]
-    NoTasksFound,
+	/// No tasks were found in the markdown content.
+	#[error("No tasks found in markdown content")]
+	NoTasksFound,
 
-    /// Failed to parse a task ID from a header.
-    #[error("Failed to parse task ID from header: {header}")]
-    InvalidTaskId { header: String },
+	/// Failed to parse a task ID from a header.
+	#[error("Failed to parse task ID from header: {header}")]
+	InvalidTaskId { header: String },
 
-    /// Failed to parse a task title from a header.
-    #[error("Failed to parse task title from header: {header}")]
-    InvalidTaskTitle { header: String },
+	/// Failed to parse a task title from a header.
+	#[error("Failed to parse task title from header: {header}")]
+	InvalidTaskTitle { header: String },
 
-    /// Failed to parse a subtask ID.
-    #[error("Failed to parse subtask ID: {id}")]
-    InvalidSubtaskId { id: String },
+	/// Failed to parse a subtask ID.
+	#[error("Failed to parse subtask ID: {id}")]
+	InvalidSubtaskId { id: String },
 
-    /// Failed to parse a subtask title.
-    #[error("Failed to parse subtask title: {title}")]
-    InvalidSubtaskTitle { title: String },
+	/// Failed to parse a subtask title.
+	#[error("Failed to parse subtask title: {title}")]
+	InvalidSubtaskTitle { title: String },
 
-    /// Failed to parse a date expression.
-    #[error("Failed to parse date expression: {expression}")]
-    InvalidDateExpression { expression: String },
+	/// Failed to parse a date expression.
+	#[error("Failed to parse date expression: {expression}")]
+	InvalidDateExpression { expression: String },
 
-    /// Failed to parse a dependency reference.
-    #[error("Failed to parse dependency reference: {reference}")]
-    InvalidDependencyReference { reference: String },
+	/// Failed to parse a dependency reference.
+	#[error("Failed to parse dependency reference: {reference}")]
+	InvalidDependencyReference { reference: String },
 
-    /// Failed to parse a duration expression.
-    #[error("Failed to parse duration expression: {expression}")]
-    InvalidDurationExpression { expression: String },
+	/// Failed to parse a duration expression.
+	#[error("Failed to parse duration expression: {expression}")]
+	InvalidDurationExpression { expression: String },
 
-    /// Missing required field in task section.
-    #[error("Missing required field '{field}' in task section")]
-    MissingRequiredField { field: String },
+	/// Missing required field in task section.
+	#[error("Missing required field '{field}' in task section")]
+	MissingRequiredField { field: String },
 
-    /// Invalid field format in task section.
-    #[error("Invalid format for field '{field}': {value}")]
-    InvalidFieldFormat { field: String, value: String },
+	/// Missing multiple required fields in task section.
+	#[error("Missing multiple required fields in task section: {fields:?}")]
+	MissingMultipleRequiredFields { fields: Vec<String> },
 
-    /// Error from the roadline builder.
-    #[error("Roadline builder error: {source}")]
-    RoadlineBuilder {
-        #[from]
-        source: RoadlineBuilderError,
-    },
+	/// Invalid field format in task section.
+	#[error("Invalid format for field '{field}': {value}")]
+	InvalidFieldFormat { field: String, value: String },
 
-    /// General parsing error with context.
-    #[error("Parsing error at line {line}: {message}")]
-    ParseError { line: usize, message: String },
+	/// Error from the roadline builder.
+	#[error("Roadline builder error: {source}")]
+	RoadlineBuilder {
+		#[from]
+		source: RoadlineBuilderError,
+	},
 
-    /// IO error when reading files.
-    #[error("IO error: {source}")]
-    Io {
-        #[from]
-        source: std::io::Error,
-    },
+	/// General parsing error with context.
+	#[error("Parsing error at line {line}: {message}")]
+	ParseError { line: usize, message: String },
 
-    /// Chrono date parsing error.
-    #[error("Date parsing error: {source}")]
-    Chrono {
-        #[from]
-        source: chrono::ParseError,
-    },
+	/// IO error when reading files.
+	#[error("IO error: {source}")]
+	Io {
+		#[from]
+		source: std::io::Error,
+	},
+
+	/// Chrono date parsing error.
+	#[error("Date parsing error: {source}")]
+	Chrono {
+		#[from]
+		source: chrono::ParseError,
+	},
 }
 
 impl MarkdownParseError {
-    /// Create a parse error with line context.
-    pub fn with_line(line: usize, message: impl Into<String>) -> Self {
-        Self::ParseError {
-            line,
-            message: message.into(),
-        }
-    }
+	/// Create a parse error with line context.
+	pub fn with_line(line: usize, message: impl Into<String>) -> Self {
+		Self::ParseError { line, message: message.into() }
+	}
 
-    /// Create an error for missing required field.
-    pub fn missing_field(field: impl Into<String>) -> Self {
-        Self::MissingRequiredField {
-            field: field.into(),
-        }
-    }
+	/// Create an error for missing required field.
+	pub fn missing_field(field: impl Into<String>) -> Self {
+		Self::MissingRequiredField { field: field.into() }
+	}
 
-    /// Create an error for invalid field format.
-    pub fn invalid_field_format(field: impl Into<String>, value: impl Into<String>) -> Self {
-        Self::InvalidFieldFormat {
-            field: field.into(),
-            value: value.into(),
-        }
-    }
+	/// Create an error for invalid field format.
+	pub fn invalid_field_format(field: impl Into<String>, value: impl Into<String>) -> Self {
+		Self::InvalidFieldFormat { field: field.into(), value: value.into() }
+	}
 }

--- a/core/parser/markdown/src/task.rs
+++ b/core/parser/markdown/src/task.rs
@@ -132,6 +132,24 @@ impl TaskParser {
 			}
 		}
 
+		// Return an error for all missing fields
+		// Collect all missing fields into a vector
+		let mut missing_fields = Vec::new();
+		if metadata.starts.is_none() {
+			missing_fields.push("Starts".to_string());
+		}
+		if metadata.depends_on.is_none() {
+			missing_fields.push("Depends-on".to_string());
+		}
+		if metadata.ends.is_none() {
+			missing_fields.push("Ends".to_string());
+		}
+		if !missing_fields.is_empty() {
+			return Err(MarkdownParseError::MissingMultipleRequiredFields {
+				fields: missing_fields,
+			});
+		}
+
 		Ok(metadata)
 	}
 

--- a/core/renderer/bevy/src/resources/pixel_scale.rs
+++ b/core/renderer/bevy/src/resources/pixel_scale.rs
@@ -12,7 +12,7 @@ pub struct PixelScale {
 
 impl Default for PixelScale {
 	fn default() -> Self {
-		Self { pixels_per_x_unit: 10.0, pixels_per_y_unit: 75.0 }
+		Self { pixels_per_x_unit: 8.0, pixels_per_y_unit: 40.0 }
 	}
 }
 

--- a/core/renderer/bevy/src/systems/task/spawning.rs
+++ b/core/renderer/bevy/src/systems/task/spawning.rs
@@ -93,8 +93,8 @@ impl TaskSpawningSystem {
 			log::info!("Max bounds: width={}, height={}", max_width_f32, max_height_f32);
 
 			let (x, y) = (start_x, start_y);
-			let height = end_y - start_y;
-			let width = end_x - start_x;
+			let height = end_y.saturating_sub(start_y);
+			let width = end_x.saturating_sub(start_x);
 
 			// Convert reified units to pixel coordinates using proper scaling
 			let pixel_x = pixel_scale.scale_x(x as f32);
@@ -406,8 +406,8 @@ mod tests {
 			let task_rect = task_rectangles.find(|(task_id, _, _, _, _)| **task_id == task.task_id);
 
 			if let Some((_, start_x, start_y, end_x, end_y)) = task_rect {
-				let width = end_x - start_x;
-				let height = end_y - start_y;
+				let width = end_x.saturating_sub(start_x);
+				let height = end_y.saturating_sub(start_y);
 
 				// Calculate expected position based on the spawning logic
 				let expected_pixel_x = start_x as f32 * custom_pixels_per_x_unit;

--- a/core/renderer/bevy/src/systems/task/spawning.rs
+++ b/core/renderer/bevy/src/systems/task/spawning.rs
@@ -83,7 +83,7 @@ impl TaskSpawningSystem {
 		// Create new task sprites for each task
 		for (task_id, start_x, start_y, end_x, end_y) in reified.task_rectangles() {
 			log::info!(
-				"task_id: {:?}, start_x: {}, start_y: {}, end_x: {}, end_y: {}",
+				"renderer spawning task_id: {:?}, start_x: {}, start_y: {}, end_x: {}, end_y: {}",
 				task_id,
 				start_x,
 				start_y,

--- a/core/renderer/bevy/src/test_utils.rs
+++ b/core/renderer/bevy/src/test_utils.rs
@@ -46,7 +46,7 @@ pub fn create_test_roadline() -> Result<CoreRoadline, anyhow::Error> {
 			StdDuration::from_secs(7 * 24 * 60 * 60),
 		);
 
-	let rodline = RoadlineBuilder::new()
+	let roadline = RoadlineBuilder::new()
 		.task(task1)?
 		.task(task2)?
 		.task(task3)?
@@ -54,5 +54,5 @@ pub fn create_test_roadline() -> Result<CoreRoadline, anyhow::Error> {
 		.task(task5)?
 		.build()?;
 
-	Ok(rodline)
+	Ok(roadline)
 }

--- a/core/representation/src/grid_algebra.rs
+++ b/core/representation/src/grid_algebra.rs
@@ -135,9 +135,10 @@ impl PreGridAlgebra {
 		for (&task_id, span) in spans {
 			let start_timestamp = span.start.inner().inner().timestamp();
 			let end_timestamp = span.end.inner().inner().timestamp();
+
 			// Convert to grid units relative to reference time
-			let start_unit = ((start_timestamp - reference_time) / unit_seconds) as u8;
-			let end_unit = ((end_timestamp - reference_time) / unit_seconds) as u8; // Floor division for simplicity
+			let start_unit = ((start_timestamp - reference_time) / unit_seconds) as u16;
+			let end_unit = ((end_timestamp - reference_time) / unit_seconds) as u16; // Floor division for simplicity
 
 			let stretch_range = StretchRange::new(start_unit, end_unit.max(start_unit + 1)); // Ensure minimum 1 unit duration
 			let stretch = Stretch::new(stretch_range, time_unit);
@@ -261,7 +262,7 @@ impl PreGridAlgebra {
 		sorted_tasks.sort_by_key(|(_, stretch)| stretch.start());
 
 		// Use a greedy algorithm to count minimum lanes needed
-		let mut lane_end_times: Vec<u8> = Vec::new();
+		let mut lane_end_times: Vec<u16> = Vec::new();
 
 		for (_, stretch) in sorted_tasks {
 			let start_time = stretch.start();
@@ -420,7 +421,7 @@ pub struct GridAlgebra {
 	time_unit: StretchUnit,
 	tasks: HashMap<TaskId, Cell>,
 	total_lanes: usize,
-	max_x_axis: u8,
+	max_x_axis: u16,
 	max_y_axis: u8,
 }
 
@@ -487,14 +488,14 @@ impl GridAlgebra {
 
 	/// Get the maximum time unit used across all tasks.
 	/// This is precomputed during grid construction for efficiency.
-	pub fn max_time_unit(&self) -> u8 {
+	pub fn max_time_unit(&self) -> u16 {
 		self.max_x_axis
 	}
 
 	/// Get the maximum x-axis value (farthest end point of any stretch).
 	/// This represents the rightmost edge of the grid.
 	/// This is precomputed during grid construction for efficiency.
-	pub fn max_x_axis(&self) -> u8 {
+	pub fn max_x_axis(&self) -> u16 {
 		self.max_x_axis
 	}
 
@@ -595,8 +596,8 @@ mod tests {
 		assert!(grid_algebra.has_task(&TaskId::new(2)));
 		assert!(grid_algebra.has_task(&TaskId::new(3)));
 
-		// Verify time unit was determined (should be Weeks with canonical method)
-		assert_eq!(grid_algebra.time_unit(), StretchUnit::Weeks);
+		// Verify time unit was determined (should be days with canonical method)
+		assert_eq!(grid_algebra.time_unit(), StretchUnit::Days);
 
 		Ok(())
 	}
@@ -670,14 +671,14 @@ mod tests {
 
 		// With tasks of 30, 15, and 10 days, average duration is ~18.3 days
 		// Canonical method: largest unit ≤ average is BiWeeks, then move to next smallest = Weeks
-		assert_eq!(grid_algebra.time_unit(), StretchUnit::Weeks);
+		assert_eq!(grid_algebra.time_unit(), StretchUnit::Days);
 
 		// Verify stretches are computed correctly (in Week units)
 		let task1_stretch = grid_algebra.task_cell(&TaskId::new(1)).unwrap().stretch();
-		assert_eq!(task1_stretch.duration(), 4); // 30 days ≈ 4 weeks floor division
+		assert_eq!(task1_stretch.duration(), 30); // 30 days
 
 		let task2_stretch = grid_algebra.task_cell(&TaskId::new(2)).unwrap().stretch();
-		assert_eq!(task2_stretch.duration(), 2); // 15 days ≈ 2 weeks floor division
+		assert_eq!(task2_stretch.duration(), 15); // 15 days
 
 		Ok(())
 	}

--- a/core/representation/src/grid_algebra.rs
+++ b/core/representation/src/grid_algebra.rs
@@ -102,17 +102,17 @@ impl PreGridAlgebra {
 		}
 
 		// Calculate average task duration in seconds
-		let total_duration_seconds: u64 = spans
+		let min_duration: u64 = spans
 			.values()
 			.map(|span| {
 				let start = span.start.inner().inner().timestamp();
 				let end = span.end.inner().inner().timestamp();
 				(end - start) as u64
 			})
-			.sum();
+			.min()
+			.ok_or(GridAlgebraError::NoTasks)?;
 
-		let average_duration = total_duration_seconds / spans.len() as u64;
-		Ok(StretchUnit::canonical_from_average_seconds(average_duration))
+		Ok(StretchUnit::canonical_from_min_secs(min_duration))
 	}
 
 	/// Calculates time boundaries and converts them to stretches.

--- a/core/representation/src/grid_algebra/stretch.rs
+++ b/core/representation/src/grid_algebra/stretch.rs
@@ -107,7 +107,7 @@ impl StretchUnit {
 
 	/// Finds the closest unit that is at most the average duration, then moves to the next smallest.
 	/// This ensures the grid has good granularity and readability.
-	pub fn canonical_from_average_seconds(average_seconds: u64) -> Self {
+	pub fn canonical_from_min_secs(average_seconds: u64) -> Self {
 		let all_units = [
 			Self::Days,
 			Self::Weeks,

--- a/core/representation/src/grid_algebra/stretch.rs
+++ b/core/representation/src/grid_algebra/stretch.rs
@@ -9,29 +9,29 @@ use serde::{Deserialize, Serialize};
 /// The start is inclusive and the end is exclusive.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct StretchRange {
-	start: u8,
-	end: u8,
+	start: u16,
+	end: u16,
 }
 
 impl StretchRange {
-	pub fn new(start: u8, end: u8) -> Self {
+	pub fn new(start: u16, end: u16) -> Self {
 		assert!(start <= end, "StretchRange start must be <= end");
 		Self { start, end }
 	}
 
-	pub fn start(&self) -> u8 {
+	pub fn start(&self) -> u16 {
 		self.start
 	}
 
-	pub fn end(&self) -> u8 {
+	pub fn end(&self) -> u16 {
 		self.end
 	}
 
-	pub fn duration(&self) -> u8 {
+	pub fn duration(&self) -> u16 {
 		self.end - self.start
 	}
 
-	pub fn contains(&self, index: u8) -> bool {
+	pub fn contains(&self, index: u16) -> bool {
 		index >= self.start && index < self.end
 	}
 
@@ -107,7 +107,7 @@ impl StretchUnit {
 
 	/// Finds the closest unit that is at most the average duration, then moves to the next smallest.
 	/// This ensures the grid has good granularity and readability.
-	pub fn canonical_from_min_secs(average_seconds: u64) -> Self {
+	pub fn canonical_from_min_secs(min_seconds: u64) -> Self {
 		let all_units = [
 			Self::Days,
 			Self::Weeks,
@@ -124,7 +124,7 @@ impl StretchUnit {
 		let mut canonical_unit = Self::Days; // Default fallback
 
 		for &unit in &all_units {
-			if unit.seconds() <= average_seconds {
+			if unit.seconds() <= min_seconds {
 				canonical_unit = unit;
 			} else {
 				break; // Units are ordered, so we can stop here
@@ -185,15 +185,15 @@ impl Stretch {
 		self.unit
 	}
 
-	pub fn start(&self) -> u8 {
+	pub fn start(&self) -> u16 {
 		self.range.start()
 	}
 
-	pub fn end(&self) -> u8 {
+	pub fn end(&self) -> u16 {
 		self.range.end()
 	}
 
-	pub fn duration(&self) -> u8 {
+	pub fn duration(&self) -> u16 {
 		self.range.duration()
 	}
 

--- a/core/representation/src/reified.rs
+++ b/core/representation/src/reified.rs
@@ -42,7 +42,7 @@ impl ReifiedConfig {
 	pub fn default_config() -> Self {
 		Self {
 			connection_trim: Trim::new(ReifiedUnit::new(3)), // 3 units of gutter space
-			inter_lane_padding: DownLanePadding::new(ReifiedUnit::new(0)), // 2 unit between lanes
+			inter_lane_padding: DownLanePadding::new(ReifiedUnit::new(1)), // 2 unit between lanes
 		}
 	}
 

--- a/core/representation/src/reified.rs
+++ b/core/representation/src/reified.rs
@@ -42,7 +42,7 @@ impl ReifiedConfig {
 	pub fn default_config() -> Self {
 		Self {
 			connection_trim: Trim::new(ReifiedUnit::new(3)), // 3 units of gutter space
-			inter_lane_padding: DownLanePadding::new(ReifiedUnit::new(1)), // 2 units between lanes
+			inter_lane_padding: DownLanePadding::new(ReifiedUnit::new(0)), // 2 unit between lanes
 		}
 	}
 

--- a/core/representation/src/reified/down_stretch.rs
+++ b/core/representation/src/reified/down_stretch.rs
@@ -63,14 +63,17 @@ impl DownStretch {
 	}
 
 	pub fn canonical_from_stretch(stretch: Stretch, trim: Trim) -> Self {
-		let unit = stretch.unit().down(1);
+		println!("stretch: {:#?}", stretch);
+		let unit = stretch.unit().down(0);
 		let (start, end) = stretch.scale(unit);
 
 		// subtract the trim from the end
-		let end = end as u16 - trim.value().value();
+		let end = (end as u16).saturating_sub(trim.value().value());
 
 		let down_stretch =
 			DownStretchRange::new(ReifiedUnit::new(start as u16), ReifiedUnit::new(end as u16));
+
+		println!("down_stretch: {:#?}", down_stretch);
 
 		Self::new(stretch, trim, down_stretch)
 	}

--- a/core/representation/src/reified/down_stretch.rs
+++ b/core/representation/src/reified/down_stretch.rs
@@ -63,7 +63,6 @@ impl DownStretch {
 	}
 
 	pub fn canonical_from_stretch(stretch: Stretch, trim: Trim) -> Self {
-		println!("stretch: {:#?}", stretch);
 		let unit = stretch.unit().down(0);
 		let (start, end) = stretch.scale(unit);
 
@@ -72,8 +71,6 @@ impl DownStretch {
 
 		let down_stretch =
 			DownStretchRange::new(ReifiedUnit::new(start as u16), ReifiedUnit::new(end as u16));
-
-		println!("down_stretch: {:#?}", down_stretch);
 
 		Self::new(stretch, trim, down_stretch)
 	}

--- a/core/representation/src/roadline.rs
+++ b/core/representation/src/roadline.rs
@@ -237,7 +237,7 @@ impl RoadlineBuilder {
 	/// Use a spacious layout configuration (generous spacing).
 	pub fn spacious(mut self) -> Self {
 		self.config = ReifiedConfig::new(
-			Trim::new(ReifiedUnit::new(5)),            // Smaller gutter for new task construction
+			Trim::new(ReifiedUnit::new(5)), // Smaller gutter for new task construction
 			DownLanePadding::new(ReifiedUnit::new(2)), // Smaller padding for new task construction
 		);
 		self
@@ -364,6 +364,8 @@ impl RoadlineBuilder {
 		if self.is_empty() {
 			return Err(RoadlineBuilderError::NoTasks);
 		}
+
+		println!("graph: {:#?}", self.graph.facts);
 
 		// Step 1: Build the range algebra (temporal positioning)
 		let range_algebra = PreRangeAlgebra::new(self.graph).compute(self.root_date)?;
@@ -577,12 +579,12 @@ mod tests {
 	use roadline_util::task::Task;
 	use std::time::Duration as StdDuration;
 
-
 	#[test]
 	fn test_builder_basic_functionality() -> Result<(), anyhow::Error> {
 		let mut builder = RoadlineBuilder::start_of_epoch()?;
 
-		let task1 = Task::test_from_id(1)?.for_standard_duration(StdDuration::from_secs(10 * 24 * 60 * 60));
+		let task1 =
+			Task::test_from_id(1)?.for_standard_duration(StdDuration::from_secs(10 * 24 * 60 * 60));
 		let task2 = Task::test_from_id(2)?
 			.after(&task1)
 			.offset_start_date(StdDuration::from_secs(5 * 24 * 60 * 60))
@@ -622,7 +624,8 @@ mod tests {
 
 	#[test]
 	fn test_fluent_api() -> Result<(), anyhow::Error> {
-		let task1 = Task::test_from_id(1)?.for_standard_duration(StdDuration::from_secs(10 * 24 * 60 * 60));
+		let task1 =
+			Task::test_from_id(1)?.for_standard_duration(StdDuration::from_secs(10 * 24 * 60 * 60));
 		let task2 = Task::test_from_id(2)?
 			.after(&task1)
 			.offset_start_date(StdDuration::from_secs(5 * 24 * 60 * 60))
@@ -657,7 +660,8 @@ mod tests {
 
 	#[test]
 	fn test_spacing_presets() -> Result<(), anyhow::Error> {
-		let task1 = Task::test_from_id(1)?.for_standard_duration(StdDuration::from_secs(10 * 24 * 60 * 60));
+		let task1 =
+			Task::test_from_id(1)?.for_standard_duration(StdDuration::from_secs(10 * 24 * 60 * 60));
 		let task2 = Task::test_from_id(2)?
 			.after(&task1)
 			.offset_start_date(StdDuration::from_secs(5 * 24 * 60 * 60))
@@ -704,7 +708,8 @@ mod tests {
 
 		// With tasks, validation should pass
 		let mut builder_with_tasks = RoadlineBuilder::new();
-		let task = Task::test_from_id(1)?.for_standard_duration(StdDuration::from_secs(10 * 24 * 60 * 60));
+		let task =
+			Task::test_from_id(1)?.for_standard_duration(StdDuration::from_secs(10 * 24 * 60 * 60));
 		builder_with_tasks.add_task(task)?;
 		assert!(builder_with_tasks.validate().is_ok());
 		Ok(())
@@ -712,7 +717,6 @@ mod tests {
 
 	#[test]
 	fn test_error_wrapping_preserves_information() -> Result<(), anyhow::Error> {
-
 		// Create a cycle: task1 -> task2 -> task1 (circular dependency)
 		let mut builder = RoadlineBuilder::new();
 		let task1 = Task::test_from_id(1)?
@@ -759,7 +763,8 @@ mod tests {
 			.with_trim(Trim::new(ReifiedUnit::new(5)))
 			.with_padding(DownLanePadding::new(ReifiedUnit::new(2)));
 
-		let task1 = Task::test_from_id(1)?.for_standard_duration(StdDuration::from_secs(10 * 24 * 60 * 60));
+		let task1 =
+			Task::test_from_id(1)?.for_standard_duration(StdDuration::from_secs(10 * 24 * 60 * 60));
 		let task2 = Task::test_from_id(2)?
 			.after(&task1)
 			.offset_start_date(StdDuration::from_secs(5 * 24 * 60 * 60))
@@ -781,7 +786,8 @@ mod tests {
 	fn test_roadline_access_methods() -> Result<(), anyhow::Error> {
 		let mut builder = RoadlineBuilder::start_of_epoch()?;
 
-		let task1 = Task::test_from_id(1)?.for_standard_duration(StdDuration::from_secs(10 * 24 * 60 * 60));
+		let task1 =
+			Task::test_from_id(1)?.for_standard_duration(StdDuration::from_secs(10 * 24 * 60 * 60));
 		let task2 = Task::test_from_id(2)?
 			.after(&task1)
 			.offset_start_date(StdDuration::from_secs(5 * 24 * 60 * 60))

--- a/core/representation/src/roadline.rs
+++ b/core/representation/src/roadline.rs
@@ -365,8 +365,6 @@ impl RoadlineBuilder {
 			return Err(RoadlineBuilderError::NoTasks);
 		}
 
-		println!("graph: {:#?}", self.graph.facts);
-
 		// Step 1: Build the range algebra (temporal positioning)
 		let range_algebra = PreRangeAlgebra::new(self.graph).compute(self.root_date)?;
 


### PR DESCRIPTION
# Summary
[RROAD-39](https://github.com/ramate-io/ramate/pull/39) revealed several bugs in the representation and rendering including:

- Too aggressive in default down scaling.
- Did not throw parsing error on missing fields. 
- Gutters oversized.

To fix, we add an overdue CLI and manually tested against RROAD-39. These are mostly hotfixes; a more complete rewrite should follow. 